### PR TITLE
Allowing rc files in non-standard places.

### DIFF
--- a/sample-rc/tob.rc.osx+gdrive
+++ b/sample-rc/tob.rc.osx+gdrive
@@ -1,0 +1,41 @@
+# Where this files lives as well as the volumes subdir
+TOBHOME="/Users/cburns/etc/tob"			
+# Where tob will keep its lists
+TOBLISTS="/Users/cburns/toblists"
+# Backup to the Google Drive mount point
+BACKUPDEV="/Volumes/GoogleDrive/My Drive/Backup/TOB/kepler"
+
+# Clear out old stuff. Make this smaller if space is premium.
+MAXBACKUPAGE=-1
+
+# If $BACKUPDEV is a directory:
+# 
+DELETIONSCOMMAND='cat >${BACKUPDEV}/${VOLUMENAME}_${DATE}_${TYPE}_deletions'
+
+# let tob be explicit
+VERBOSE='yes'				
+
+# Should find be nice'd ?
+NICEFIND='no'
+
+# File extension for archives
+EXT=tgz
+
+# BACKUPDEV is the actual name of the archive file. 
+# Note the double-quotes around $BACKUPDEV...  that's to deal with the fact
+# that there is a space in $BACKUPDEV (My Drive)
+BACKUPCMD='tar -cpz --no-recursion -T $FILELIST -f "$BACKUPDEV"'
+
+BACKUPCMDTOSTDOUT='tar -cz  --no-recursion -T $FILELIST -f -'
+
+# This command will be run on the cloud drive, so could be super-slow.
+# Issue a warning message, then continue.
+LISTCMD='echo "Warning: Listing archive from the cloud may take a LONG time"; tar -tz -f "$BACKUPDEV"'
+
+# BACKUPDEV is the fully qualified name of the archive. Again, use double-quotes
+# to ensure paths with spaces in them are interpreted correctly. And in OSX,
+# and empty FILESPEC is not allowed, need to default to "*"
+RESTORECMD='tar -xvzf "$BACKUPDEV" "${FILESPEC:-*}"'
+
+# Assume this is being run in user-space
+NEEDROOT='no'

--- a/sample-rc/tob.rc.rclone
+++ b/sample-rc/tob.rc.rclone
@@ -1,0 +1,49 @@
+# Use rclone to treat cloud storage as a the backup device. This solution works
+# on Linux systems that currently don't have very good google-drive clients.
+# This requires setting BACKUPDEV to a scratch folder, where the archive is
+# initially created, then sent to the cloud. So a limitation is that you need
+# enough free space on some partition to create your backup.
+
+# Where this files lives as well as the volumes subdir
+TOBHOME="/home/cburns/etc/tob"			
+# Where tob will keep its lists
+TOBLISTS=/home/cburns/toblists
+# Backup to the RAID (/data is a link to /data001 or /data002)
+BACKUPDEV="/data/cburns/Backups"
+# The cloud location of your archives in the format recognized by rclone
+CLOUDLOC="Gdrive:Backup/TOB"
+
+# Clear out old stuff. Make this smaller if space is premium.
+MAXBACKUPAGE=-1
+
+# If $BACKUPDEV is a directory:
+# 
+DELETIONSCOMMAND='cat >${BACKUPDEV}/${VOLUMENAME}_${DATE}_${TYPE}_deletions'
+
+# let tob be explicit
+VERBOSE='yes'				
+
+# Should find be nice'd ?
+NICEFIND='no'
+
+# File extension for archives
+EXT=tgz
+
+# BACKUPDEV is the actual name of the archive file. Use rclone to copy it to 
+# cloud drive after it's made, then replace with stub file containing location
+# on the cloud
+BACKUPCMD='tar -cpz --no-recursion --ignore-failed-read -T $FILELIST -f $BACKUPDEV && rclone move $BACKUPDEV $CLOUDLOC && echo "${CLOUDLOC}/$(basename $BACKUPDEV)" > $BACKUPDEV'
+
+BACKUPCMDTOSTDOUT='tar -cz  --no-recursion --ignore-failed-read -T $FILELIST -f -'
+
+# Listing all archive contents would require downloading them all from the
+# cloud. I don't think we want to do this, so disable it with error message.
+# But if you want to be able to do this, uncomment next line.
+# LISTCMD='cp ${BACKUPDEV} ${BACKUPDEV}.log && rclone copy $(cat ${BACKUPDEV}.loc) $(dirname $BACKUPDEV) && tar -tz -f $BACKUPDEV && mv ${BACKUPDEV}.loc ${BACKUPDEV}'
+LISTCMD='echo "verbose listing not supported on the cloud"'
+
+# BACKUPDEV is the fully qualified name of the archive. Get it from Gdrive and
+# un-archive it, then replace with stub file when we're done.
+RESTORECMD='cp ${BACKUPDEV} ${BACKUPDEV}.loc && rclone copy $(cat ${BACKUPDEV}.loc) $(dirname $BACKUPDEV) && tar -xvzf $BACKUPDEV "$FILESPEC" && mv ${BACKUPDEV}.loc ${BACKUPDEV}'
+
+NEEDROOT='no'

--- a/sample-rc/tob.rc.rclone_mount
+++ b/sample-rc/tob.rc.rclone_mount
@@ -1,0 +1,49 @@
+# Sample tob.rc file for use with rclone mount sub-command. 'rclone mount'
+# lets you mount your cloud server as a local mount point. This requires
+# a pretty new version of rclone and also the FUSE libraries. If you system
+# doesn't have them, talk to your systems admin.
+
+# Where this file lives as well as the volumes subdir
+TOBHOME="/home/cburns/etc/tob"			
+# Where tob will keep its lists
+TOBLISTS="/home/cburns/toblists"
+# This should be the mount point you've setup with "rclone mount". For example,
+# if your cloud server is gdrive: and you've created a 'backup' folder as
+# the mount point:
+#    $ rclone mount gdrive:Backup/TOB /home/cburns/backup
+BACKUPDEV="/home/cburns/backup"
+
+# Clear out old stuff. Make this positive if space is premium.
+MAXBACKUPAGE=-1
+
+# If $BACKUPDEV is a directory:
+# 
+DELETIONSCOMMAND='cat >${BACKUPDEV}/${VOLUMENAME}_${DATE}_${TYPE}_deletions'
+
+# let tob be explicit
+VERBOSE='yes'				
+
+# Should find be nice'd ?
+NICEFIND='no'
+
+# File extension for archives
+EXT=tgz
+
+# BACKUPDEV is the actual name of the archive file. 
+# Note the double-quotes around $BACKUPDEV...  that's to deal with the fact
+# that there is a space in $BACKUPDEV (My Drive)
+BACKUPCMD='tar -cpz --no-recursion -T $FILELIST -f "$BACKUPDEV"'
+
+BACKUPCMDTOSTDOUT='tar -cz  --no-recursion -T $FILELIST -f -'
+
+# This command will be run on the cloud drive, so could be super-slow.
+# Issue a warning message, then continue.
+LISTCMD='echo "Warning: Listing archive from the cloud may take a LONG time"; tar -tz -f "$BACKUPDEV"'
+
+# BACKUPDEV is the fully qualified name of the archive. Again, use double-quotes
+# to ensure paths with spaces in them are interpreted correctly. And in OSX,
+# and empty FILESPEC is not allowed, need to default to "*"
+RESTORECMD='tar -xvzf "$BACKUPDEV" "${FILESPEC:-*}"'
+
+# Assume this is being run in user-space
+NEEDROOT='no'

--- a/tob
+++ b/tob
@@ -62,7 +62,7 @@ EXT='gz'
 ## 16 May 1998
 ##
 ## Smartened up by Stephen van Egmond <svanegmond@tinyplanet.ca> 2003/10/30
-MKTEMP=`which maketemp`;
+MKTEMP=`which maketemp 2> /dev/null`;
 if [ ! -x "$MKTEMP" ]; then
 	MKTEMP=`which mktemp`;
 fi
@@ -169,10 +169,6 @@ getrcname ()
 	    found='yes'
 	fi
     done
-
-    if [ "$found" = "no" ] ; then
-	error "no resource file \"tob.rc\" found."
-    fi
 }    
 
 ###########################################################################
@@ -206,6 +202,9 @@ checkenv ()
 # read resource files
 readrc ()
 {
+    if [ "$RCFILE" = "none" ] ; then
+    	error "no resource file \"tob.rc\" found."
+    fi
     . "$RCFILE" || error "Syntax error in $RCFILE?"
     message "Ok, got resource $RCFILE."
 
@@ -785,6 +784,7 @@ getrcname
 
 umask 026
 
+RCFILE="none"
 # default type argument to RC file is "none"
 TYPE="none"
 
@@ -795,7 +795,7 @@ while [ "$ready" = "no" ] ; do
 	-rc)
 	    shift
 	    RCFILE=$1
-	    # message "will use alternate resource file $RCFILE."
+	    message "will use alternate resource file $RCFILE."
 	    shift
 	    ready=no
 	    ;;

--- a/tob
+++ b/tob
@@ -111,6 +111,9 @@ RM="/bin/rm"
 LS="/bin/ls"
 GREP="/bin/grep"
 
+# Find the appropriate "find". Use 'gfind' if available
+FIND=`which gfind` || FIND="find"
+
 # Separator Definition: change to " " to get the standard behaviour back,
 # but note that this will break '-find' on files with spaces in their names 
 S="`echo -e \"\\001\"`"
@@ -347,7 +350,7 @@ makefulllist ()
     #		       'findswitch' also removed from the paragraph after next
 
   cat $TOBHOME/volumes/$1.startdir | \
-  xargs -i $nicefindcmd find {} $xdevflag  -printf '%p'$S'[ctime:] %C@ [owner/group:]  %u:%g' \( \( -fstype fat -or -fstype vfat \) -and -printf ' [mtime:] %T@' -or -printf ' [inode:] %i' \) -printf ' [linkto:] %l [perm:] %m [hardlinks:] %n\n' | \
+  xargs -I{} $nicefindcmd $FIND {} $xdevflag  -printf '%p'$S'[ctime:] %C@ [owner/group:]  %u:%g' \( \( -fstype fat -or -fstype vfat \) -and -printf ' [mtime:] %T@' -or -printf ' [inode:] %i' \) -printf ' [linkto:] %l [perm:] %m [hardlinks:] %n\n' | \
 	sed -e 's.\\.\\\\.g' | \
 	# If the exclude file contains non-blank lines, filter against it.
 	# If it is empty, or doesn't exist, just cat stdin to stdout
@@ -586,7 +589,7 @@ deleteoldbackups ()
 	cd `dirname $BACKUPDEV`
 	message "Deleting old backups from `dirname $BACKUPDEV`:"
 	PR=""; [ "$VERBOSE" == "yes" ] && PR="-print"
-	find . -regex ./${VOLUMENAME}_'.*\('$1'\).*' -type f -mtime +$MAXBACKUPAGE ! -name "$UPTO" -exec $RM -f {} \; $PR
+	$FIND . -regex ./${VOLUMENAME}_'.*\('$1'\).*' -type f -mtime +$MAXBACKUPAGE ! -name "$UPTO" -exec $RM -f {} \; $PR
     fi
 }
 

--- a/tob
+++ b/tob
@@ -497,7 +497,7 @@ runverify ()
     VOLUMENAME=$2		     # store name for usage in .rc file
 
     if [ -d "$BACKUPDEV" ]; then
-        BACKUPDEV=(`$LS ${BACKUPDEV}/${VOLUMENAME}_*full.${EXT}`)
+        BACKUPDEV=(`$LS "${BACKUPDEV}"/${VOLUMENAME}_*full.${EXT}`)
         if [ ${#BACKUPDEV[*]} -ne 1 ]; then
             error "More than one full backup to choose from.  Use -f to select one."
         fi
@@ -585,9 +585,9 @@ deleteoldbackups ()
     # Since runbackups has run, $BACKUPDEV is either a file or a device.
     # We only do deletions when it is a file.
     if [ "$MAXBACKUPAGE" -ge 0 -a -f "$BACKUPDEV" ]; then
-	UPTO=`basename $BACKUPDEV`
-	cd `dirname $BACKUPDEV`
-	message "Deleting old backups from `dirname $BACKUPDEV`:"
+	UPTO=`basename "$BACKUPDEV"`
+	cd "`dirname "$BACKUPDEV"`"
+	message "Deleting old backups from `dirname "$BACKUPDEV"`:"
 	PR=""; [ "$VERBOSE" == "yes" ] && PR="-print"
 	$FIND . -regex ./${VOLUMENAME}_'.*\('$1'\).*' -type f -mtime +$MAXBACKUPAGE ! -name "$UPTO" -exec $RM -f {} \; $PR
     fi
@@ -701,7 +701,7 @@ verbose ()
 {
     message "Generating report of $BACKUPDEV."
     if [ -d "$BACKUPDEV" ]; then
-      for i in `$LS ${BACKUPDEV}/*.${EXT}`; do
+      $LS "${BACKUPDEV}"/*.${EXT} | while read i ; do
       	BACKUPDEV=$i
 	eval "$LISTCMD"
       done
@@ -722,11 +722,13 @@ restore ()
     cd $startdir || error "bad starting directory $startdir."
     
     FILESPEC=$3
+    echo "FILESPEC: ${FILESPEC-*}"
     message "Restoring volume $VOLUMENAME files matching $FILESPEC into $startdir."
 
     if [ -d "$BACKUPDEV" ]; then
-       for i in `$LS ${BACKUPDEV}/${VOLUMENAME}_*.${EXT}`; do
+       $LS "${BACKUPDEV}"/${VOLUMENAME}_*.${EXT} | while read i; do
           BACKUPDEV=$i
+          echo "$RESTORECMD"
 	  eval "$RESTORECMD" && message "restored data from $i"
        done
     else


### PR DESCRIPTION
Small suggestion to move the test for the RCFILE into readrc(). Otherwise, if you try to specify an rc file from the command line (-rc {file location}), tob ignores it.

Also, added an example rc file that I came up with to send archives to cloud storage (e.g., google drive) using rclone.